### PR TITLE
Integrate into the build task by npm.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+node_modules

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "markdown theme standard style, using less (for haroopad)",
   "main": "Gruntfile.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "grunt"
   },
   "repository": {
     "type": "git",
@@ -21,6 +22,7 @@
   "devDependencies": {
     "grunt": "~0.4.0",
     "grunt-contrib-less": "~0.5.0",
-    "grunt-contrib-copy": "~0.7.0"
+    "grunt-contrib-copy": "~0.7.0",
+    "grunt-cli": "~1.1.0"
   }
 }


### PR DESCRIPTION
Integrate into the build task by npm.
Can execute build task even if there isn't a grunt-cli on local :)

```
npm install
npm run build
```
